### PR TITLE
fix propagation of ontologyTerms for templates

### DIFF
--- a/src/converter/converter.js
+++ b/src/converter/converter.js
@@ -10,7 +10,9 @@ function fromXLSXToJson(data) {
 
 function fromJsonToGenerated(data) {
     let graphData = fromJSON(JSON.parse(data));
-    graphData.neurulator();
+    if (typeof graphData.neurulator === "function") {
+        graphData.neurulator();
+    }
     let result = JSON.stringify(graphData.toJSON(3, {
         [$Field.border]   : 3,
         [$Field.borders]  : 3,

--- a/src/model/groupModel.js
+++ b/src/model/groupModel.js
@@ -224,7 +224,7 @@ export class Group extends Resource {
                         [$Field.skipLabel]: true,
                         [$Field.generated]: true
                     };
-                    template::merge(material::pick([$Field.name, $Field.external, $Field.color]));
+                    template::merge(material::pick([$Field.name, $Field.external, $Field.ontologyTerms, $Field.color]));
                     json.lyphs.push(template);
                 }
             }

--- a/src/model/groupTemplateModel.js
+++ b/src/model/groupTemplateModel.js
@@ -46,6 +46,10 @@ export class GroupTemplate extends Resource{
             group.external = template.external;
         }
 
+        if (template.ontologyTerms){
+            group.ontologyTerms = template.ontologyTerms;
+        }
+
         if (!parentGroup.groups) { parentGroup.groups = []; }
         parentGroup.groups.push(group.id);
         return group;


### PR DESCRIPTION
during the refactor from externals -> ontologyTerms there were a number
of cases were .externals is referenced directly in ways that do not
compose with subClassOf style behavior

this commit fixes the case for templates and group templates where the
absense broke a number of queries

there are almost certainly other cases where inheritance is not behaving
as expected due to some specific explicit reference to .externals