### PR TITLE
wrapper filehandler fix ArrayBuffer issues and add cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.4.0",
     "@babel/plugin-proposal-function-bind": "^7.2.0",
+	"@babel/plugin-proposal-object-rest-spread": "^7.18.6",
     "@babel/plugin-syntax-async-generators": "^7.2.0",
     "@babel/plugin-syntax-flow": "^7.18.6",
     "@babel/plugin-transform-destructuring": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "test": "mochapack --opts mocha-webpack.opts --timeout 50000 test/**/*.spec.js",
     "build": "node src/version/update-version.js && cross-env BABEL_ENV=production webpack",
+    "build-converter": "node src/version/update-version.js && cross-env BABEL_ENV=production webpack --config webpack.config-converter.js",
+    "build-converter-dev": "node src/version/update-version.js && cross-env BABEL_ENV=dev webpack --config webpack.config-converter-dev.js",
     "build-demo": "node src/version/update-version.js && cross-env BABEL_ENV=production webpack --config webpack.config-demo.js",
     "build-hubmap": "cross-env BABEL_ENV=production webpack --config webpack.config-hubmap.js",
     "watch": "webpack --progress --watch",

--- a/src/model/graphModel.js
+++ b/src/model/graphModel.js
@@ -692,12 +692,19 @@ export class Graph extends Group {
             delete obj['collide'];
             delete obj['scale'];
             delete obj['scaleFactor'];
+            // FIXME when serializing the top level group/graph need to remove imported lyphs etc.
             return obj;
         }
 
         let alsothis = this;
         function ns (obj) {
-            return  !(obj instanceof Resource) || (obj instanceof External) || alsothis.namespace === obj.namespace;
+            return  !(obj instanceof Resource) || (obj instanceof External
+                                                   && ( Object.hasOwn(obj, 'annotates') ?
+                                                        obj.annotates.filter(a =>
+                                                            a.namespace === alsothis.namespace &&
+                                                                a.id !== alsothis.id).length !== 0
+                                                        : false )
+                                                  ) || alsothis.namespace === obj.namespace;
         }
 
         (this.entitiesByID||{})::values()

--- a/src/model/graphModel.js
+++ b/src/model/graphModel.js
@@ -1,6 +1,7 @@
 //Do not include modelClasses here, it creates circular dependency
-import {Group} from './groupModel';
-import {Resource} from "./resourceModel";
+import { Group } from './groupModel';
+import { Resource, External } from "./resourceModel";
+//import {EDGE_STROKE} from "./utils";
 import {
     entries, keys, values,
     isNumber, isArray, isObject, isString, isEmpty,
@@ -643,6 +644,7 @@ export class Graph extends Group {
         };
 
         let contextPrefix = "local"; // FIXME not sure what the issue is here with "" ...
+                                     // https://github.com/w3c/json-ld-syntax/issues/12
         localContext[contextPrefix] = localContext["@base"];
 
         let schemaContext = schemaToContext(schema, {});
@@ -668,14 +670,44 @@ export class Graph extends Group {
         };
 
         function addType(obj) {
+            // and general cleanup
             obj.class === "OntologyTerm" ?
                 obj["@type"] = "owl:Class" :
-                obj["@type"] = "owl:NamedIndividual";
+                obj["@type"] = "owl:NamedIndividual" ;
+            if (obj.class === "OntologyTerm") { delete obj['generated'] }
+            delete obj['border']; // FIXME XXX weird circular brokeness when trying to serialize scaffolds when there is a 'host' property
+            delete obj['id'];  // sigh
+            delete obj['namespace'];  // sigh
+            delete obj['localConventions']; // sigh
+            // cosmetics that are just noise
+            delete obj['length'];
+            delete obj['width'];
+            delete obj['height'];
+            delete obj['layout'];
+            delete obj['radius'];
+            delete obj['thickness'];
+            delete obj['color'];
+            delete obj['lineWidth'];
+            delete obj['hidden'];
+            delete obj['collide'];
+            delete obj['scale'];
+            delete obj['scaleFactor'];
             return obj;
         }
 
-        (this.entitiesByID || {})::values()
-            .forEach(obj => res["@graph"].push((obj instanceof Resource) ? addType(obj.toJSON()) : obj));
+        let alsothis = this;
+        function ns (obj) {
+            return  !(obj instanceof Resource) || (obj instanceof External) || alsothis.namespace === obj.namespace;
+        }
+
+        (this.entitiesByID||{})::values()
+            .forEach(obj =>
+                ns(obj) ? // so you can use the ternary operator but not an if statement ... sigh
+                    res["@graph"].push(
+                        (obj instanceof Resource) ? addType(obj.toJSON()) :
+                            (obj instanceof Object) ? null : obj // avoid including stray objects
+                    ) : null
+            );
 
         return res;
     }
@@ -685,10 +717,12 @@ export class Graph extends Group {
      */
     static entitiesToJSONLDFlat(res, callback, errorCallback) {
         let context = {};
+        let bc = res['@context']['@base'];
         res['@context']::entries().forEach(([k, v]) => {
-            if (!(v::isObject() && ("@id" in v) && v["@id"].includes("apinatomy:"))) {
-                if (!(typeof (v) === "string" && v.includes("apinatomy:"))) {
-                    if (k !== "class") {
+            if (!(v::isObject() && ("@id" in v) && ( v["@id"].includes("apinatomy:") || v["@id"] === bc ))) {
+                if (!(typeof(v) === "string" && (v.includes("apinatomy:")
+                                                 || v === bc && ( k !== "@base" && k !== "local" )))) {
+                    if (k !== "class" && k !== "fullID") {
                         context[k] = v;
                     }
                 }

--- a/src/model/graphModel.js
+++ b/src/model/graphModel.js
@@ -74,7 +74,7 @@ let baseContext = {
     "topology": {
         "@id": "apinatomy:topology",
         "@type": "@id",
-        "@context": {"@base": " "}
+        "@context": {"@base": "https://apinatomy.org/uris/readable/"}
     },
 };
 

--- a/src/model/graphModel.js
+++ b/src/model/graphModel.js
@@ -681,6 +681,7 @@ export class Graph extends Group {
             delete obj['namespace'];  // sigh
             delete obj['localConventions']; // sigh
             // cosmetics that are just noise
+            delete obj['imported'];
             delete obj['length'];
             delete obj['width'];
             delete obj['height'];
@@ -698,7 +699,7 @@ export class Graph extends Group {
         }
 
         let alsothis = this;
-        function ns (obj) {
+        function include_in_export (obj) {
             return  !(obj instanceof Resource) ||
                 (obj instanceof External
                  && ( Object.hasOwn(obj, 'annotates') ?
@@ -715,7 +716,7 @@ export class Graph extends Group {
 
         (this.entitiesByID||{})::values()
             .forEach(obj =>
-                ns(obj) ? // so you can use the ternary operator but not an if statement ... sigh
+                include_in_export(obj) ? // so you can use the ternary operator but not an if statement ... sigh
                     res["@graph"].push(
                         (obj instanceof Resource) ? addType(obj.toJSON()) :
                             (obj instanceof Object) ? null : obj // avoid including stray objects

--- a/src/model/graphModel.js
+++ b/src/model/graphModel.js
@@ -1,6 +1,6 @@
 //Do not include modelClasses here, it creates circular dependency
 import { Group } from './groupModel';
-import { Resource, External } from "./resourceModel";
+import { Resource, External, Reference } from "./resourceModel";
 //import {EDGE_STROKE} from "./utils";
 import {
     entries, keys, values,
@@ -674,7 +674,8 @@ export class Graph extends Group {
             obj.class === "OntologyTerm" ?
                 obj["@type"] = "owl:Class" :
                 obj["@type"] = "owl:NamedIndividual" ;
-            if (obj.class === "OntologyTerm") { delete obj['generated'] }
+            if (["External", "OntologyTerm", "Reference"].includes(obj.class)) { delete obj['generated'] } // FIXME why does instanceof fail here ...
+            if (obj.class === "Reference" && obj.namespace !== alsothis.namespace) { delete obj['uri'] }
             delete obj['border']; // FIXME XXX weird circular brokeness when trying to serialize scaffolds when there is a 'host' property
             delete obj['id'];  // sigh
             delete obj['namespace'];  // sigh
@@ -698,13 +699,18 @@ export class Graph extends Group {
 
         let alsothis = this;
         function ns (obj) {
-            return  !(obj instanceof Resource) || (obj instanceof External
-                                                   && ( Object.hasOwn(obj, 'annotates') ?
-                                                        obj.annotates.filter(a =>
-                                                            a.namespace === alsothis.namespace &&
-                                                                a.id !== alsothis.id).length !== 0
-                                                        : false )
-                                                  ) || alsothis.namespace === obj.namespace;
+            return  !(obj instanceof Resource) ||
+                (obj instanceof External
+                 && ( Object.hasOwn(obj, 'annotates') ?
+                      obj.annotates.filter(a =>
+                          a.namespace === alsothis.namespace &&
+                              a.id !== alsothis.id).length !== 0
+                      : false )) ||
+                (obj instanceof Reference
+                 && (obj.namespace === alsothis.namespace ||
+                     // FIXME evil hardcoded hack to deal with import issues
+                     obj.namespace !== "wbkg")) ||
+                alsothis.namespace === obj.namespace;
         }
 
         (this.entitiesByID||{})::values()

--- a/src/model/resourceModel.js
+++ b/src/model/resourceModel.js
@@ -335,13 +335,20 @@ export class Resource{
          */
         function valueToJSON(value, depth) { return (value instanceof Resource)? value.toJSON(depth-1, inlineResources): value }
 
+        let alsothis = this;
+        function removeImported(obj) {
+            return (obj instanceof Resource && Object.hasOwn(obj, 'namespace')) ?
+                // FIXME need to exclude externals from the big list probably, individual refs are ok
+                (alsothis.namespace === obj.namespace || obj instanceof External) : true
+        }
+
         /**
          * Serializes field value: array or object
          * @param value - resource field value
          * @param depth - depth of nested resources to output
          * @returns {*} JSON object or an array of JSON objects without circular references
          */
-        function fieldToJSON(value, depth) { return value::isArray()? value.map(e => valueToJSON(e, depth)): valueToJSON(value, depth); }
+        function fieldToJSON(value, depth) { return value::isArray()? value.filter(removeImported).map(e => valueToJSON(e, depth)): valueToJSON(value, depth); }
 
         if (depth <= 0) {
             return this.fullID || this.id || null;

--- a/src/model/resourceModel.js
+++ b/src/model/resourceModel.js
@@ -348,7 +348,11 @@ export class Resource{
          * @param depth - depth of nested resources to output
          * @returns {*} JSON object or an array of JSON objects without circular references
          */
-        function fieldToJSON(value, depth) { return value::isArray()? value.filter(removeImported).map(e => valueToJSON(e, depth)): valueToJSON(value, depth); }
+        function fieldToJSON(value, depth) { return value::isArray() ?
+                                             // XXX the logic used for removeImported fails catastrophically for Externals due to
+                                             // the namespace mismatch so we just skip them entirely until we can fix the logic
+                                             (alsothis instanceof External ? value : value.filter(removeImported)).map(e => valueToJSON(e, depth))
+                                             : valueToJSON(value, depth); }
 
         if (depth <= 0) {
             return this.fullID || this.id || null;

--- a/webpack.config-converter-dev.js
+++ b/webpack.config-converter-dev.js
@@ -1,0 +1,22 @@
+const path    = require('path');
+const loaders = require('./webpack.loaders.js');
+const plugins = require('./webpack.plugins.js');
+
+module.exports = {
+    mode: 'development',
+    devtool: 'source-map',
+  	context: path.resolve(__dirname, 'src/'),
+    entry: {
+	    'converter': [ '@babel/polyfill', 'reflect-metadata', './converter/converter.js' ]
+    },
+	output: {
+		path: __dirname + '/dist',
+        publicPath: '',
+		filename: '[name].js',
+		sourceMapFilename: '[file].map',
+ 	},
+	module: {
+		rules: loaders
+	},
+	plugins: plugins
+};

--- a/webpack.config-converter.js
+++ b/webpack.config-converter.js
@@ -1,0 +1,24 @@
+const path    = require('path');
+const loaders = require('./webpack.loaders.js');
+const plugins = require('./webpack.plugins.js');
+
+module.exports = {
+    mode: 'production',
+    devtool: 'source-map',
+  	context: path.resolve(__dirname, 'src/'),
+    entry: {
+	    'converter': [ '@babel/polyfill', 'reflect-metadata', './converter/converter.js' ]
+    },
+	output: {
+		path: __dirname + '/dist',
+        publicPath: '',
+		filename: '[name].js',
+		sourceMapFilename: '[file].map',
+		devtoolModuleFilenameTemplate:         '[absolute-resource-path]',
+		devtoolFallbackModuleFilenameTemplate: '[absolute-resource-path]?[hash]'
+ 	},
+	module: {
+		rules: loaders
+	},
+	plugins: plugins
+};


### PR DESCRIPTION
for some reason fs can no longer write the ArrayBuffer type, so add a caste to avoid issues

also it seems that one of the dependencies is failing to clean up file handles which is preventing the script from exiting, so we use a hack to manually clean everything up after the final step completes, for json-ld -> flattened this means we have to manually set this.result in the callback and have to rename this to avoid issues